### PR TITLE
chore: update launchdarkly-openfeature-server from ^0.2.0 to ^0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"
-launchdarkly-openfeature-server = "^0.2.0"
+launchdarkly-openfeature-server = "^0.5.0"
 
 
 [build-system]


### PR DESCRIPTION
## Summary

Bumps the `launchdarkly-openfeature-server` dependency from `^0.2.0` (resolves to `>=0.2.0, <0.3.0`) to `^0.5.0` (`>=0.5.0, <0.6.0`) to ensure the example works with the latest release (0.5.1).

Tested locally: the example runs successfully with 0.5.1 — no code changes were needed.

## Review & Testing Checklist for Human

- [ ] Confirm the jump from 0.2.x to 0.5.x doesn't introduce any behavioral changes relevant to this example (the agent only tested a single boolean flag evaluation)
- [ ] Run `poetry install && LAUNCHDARKLY_SDK_KEY=<key> LAUNCHDARKLY_FLAG_KEY=sample-feature poetry run python main.py` to verify end-to-end

### Notes
- `poetry.lock` is in `.gitignore` for this repo, so no lock file changes are included.
- Link to Devin Session: https://app.devin.ai/sessions/8b0a4069b434416dbaa05daac9bd26f9
- Requested by: @kinyoklion
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/launchdarkly/hello-openfeature-python-server/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
