### PR TITLE
chore: update launchdarkly-openfeature-server to 0.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"
-launchdarkly-openfeature-server = "^0.5.0"
+launchdarkly-openfeature-server = "^0.5.1"
 
 
 [build-system]


### PR DESCRIPTION
## Summary

Update `launchdarkly-openfeature-server` dependency from `^0.5.0` to `^0.5.1` in `pyproject.toml`.

v0.5.1 is a bug fix release that removes the tests package from the distribution.

Tested locally — app runs successfully and evaluates feature flags as expected.

No deprecated APIs found. No code changes required.

Link to Devin session: https://app.devin.ai/sessions/dbaaeebcb73149b993c9acfe445ba5aa
Requested by: @kinyoklion